### PR TITLE
Redis client may was created from connection

### DIFF
--- a/Redis/Client.php
+++ b/Redis/Client.php
@@ -9,7 +9,7 @@ class Client extends \Predis\Client implements ClientInterface
      */
     public function __construct($parameters = null, $options = null)
     {
-        if (\count($parameters) === 1) {
+        if (is_array($parameters) && \count($parameters) === 1) {
             $parameters = \array_shift($parameters);
         }
 


### PR DESCRIPTION
https://github.com/predis/predis/blob/main/src/Client.php#L94
```
     * This method accepts the following types to create a connection instance:
     *
     *  - Array (dictionary: single connection, indexed: aggregate connections)
     *  - String (URI for a single connection)
     *  - Callable (connection initializer callback)
     *  - Instance of Predis\Connection\ParametersInterface (used as-is)
     *  - Instance of Predis\Connection\ConnectionInterface (returned as-is)
```

Found this bug when tried to use this bundle with Symfony Cache component
https://github.com/symfony/cache/blob/5.x/Traits/RedisTrait.php#L68